### PR TITLE
Fix 3 dim hash_vec function

### DIFF
--- a/src/common/eigen_types.h
+++ b/src/common/eigen_types.h
@@ -104,7 +104,7 @@ inline size_t hash_vec<2>::operator()(const Eigen::Matrix<int, 2, 1>& v) const {
 
 template <>
 inline size_t hash_vec<3>::operator()(const Eigen::Matrix<int, 3, 1>& v) const {
-    return size_t((v[0] * 73856093) ^ (v[1] * 471943) ^ (v[2] * 83492791) % 10000000);
+    return size_t(((v[0] * 73856093) ^ (v[1] * 471943) ^ (v[2] * 83492791)) % 10000000);
 }
 
 constexpr auto less_vec2i = [](const Vec2i& v1, const Vec2i& v2) {


### PR DESCRIPTION
Add the missing brackets before performing the modulo operation in the hash_vec function for 3-dimensional data. The brackets matter because the modulo operator % has higher precedence than the bitwise XOR operator ^ in C++. 