### PR TITLE
Add sad::SaveCloudToFile function

### DIFF
--- a/src/ch7/CMakeLists.txt
+++ b/src/ch7/CMakeLists.txt
@@ -16,6 +16,7 @@ add_library(${PROJECT_NAME}.ch7
 target_link_libraries(${PROJECT_NAME}.ch7
         ${PROJECT_NAME}.ch3
         ${PROJECT_NAME}.ch5
+        ${PROJECT_NAME}.common
         ${third_party_libs}
         )
 
@@ -26,6 +27,7 @@ add_executable(test_icp
 target_link_libraries(test_icp
         ${PROJECT_NAME}.ch5
         ${PROJECT_NAME}.ch7
+        ${PROJECT_NAME}.common
         ${third_party_libs}
         )
 
@@ -91,5 +93,6 @@ add_executable(run_gen_simu_data
 target_link_libraries(run_gen_simu_data
         ${PROJECT_NAME}.ch5
         ${PROJECT_NAME}.ch7
+        ${PROJECT_NAME}.common
         ${third_party_libs}
         )

--- a/src/ch7/loam-like/loam_like_odom.cc
+++ b/src/ch7/loam-like/loam_like_odom.cc
@@ -6,6 +6,7 @@
 #include "ch7/loam-like/feature_extraction.h"
 #include "common/lidar_utils.h"
 #include "common/math_utils.h"
+#include "common/point_cloud_utils.h"
 
 #include <execution>
 
@@ -277,7 +278,7 @@ SE3 LoamLikeOdom::AlignWithLocalMap(CloudPtr edge, CloudPtr surf) {
 
 void LoamLikeOdom::SaveMap(const std::string& path) {
     if (global_map_ && global_map_->empty() == false) {
-        pcl::io::savePCDFileBinaryCompressed(path, *global_map_);
+        sad::SaveCloudToFile(path, *global_map_);
     }
 }
 

--- a/src/ch7/loosely_coupled_lio/loosely_lio.cc
+++ b/src/ch7/loosely_coupled_lio/loosely_lio.cc
@@ -3,6 +3,7 @@
 
 #include "common/lidar_utils.h"
 #include "common/timer/timer.h"
+#include "common/point_cloud_utils.h"
 #include "loosely_lio.h"
 
 namespace sad {
@@ -104,7 +105,7 @@ void LooselyLIO::Undistort() {
     SE3 T_end = SE3(imu_state.R_, imu_state.p_);
 
     if (options_.save_motion_undistortion_pcd_) {
-        pcl::io::savePCDFileBinary("./data/ch7/before_undist.pcd", *cloud);
+        sad::SaveCloudToFile("./data/ch7/before_undist.pcd", *cloud);
     }
 
     /// 将所有点转到最后时刻状态上
@@ -127,7 +128,7 @@ void LooselyLIO::Undistort() {
     scan_undistort_ = cloud;
 
     if (options_.save_motion_undistortion_pcd_) {
-        pcl::io::savePCDFileBinary("./data/ch7/after_undist.pcd", *cloud);
+        sad::SaveCloudToFile("./data/ch7/after_undist.pcd", *cloud);
     }
 }
 

--- a/src/ch7/test/run_gen_simu_data.cc
+++ b/src/ch7/test/run_gen_simu_data.cc
@@ -7,12 +7,14 @@
 
 #include <pcl/io/pcd_io.h>
 
+#include "common/point_cloud_utils.h"
+
 int main(int argc, char** argv) {
     sad::GenSimuData gen;
     gen.Gen();
 
-    pcl::io::savePCDFileBinaryCompressed("./data/ch7/sim_source.pcd", *gen.GetSource());
-    pcl::io::savePCDFileBinaryCompressed("./data/ch7/sim_target.pcd", *gen.GetTarget());
+    sad::SaveCloudToFile("./data/ch7/sim_source.pcd", *gen.GetSource());
+    sad::SaveCloudToFile("./data/ch7/sim_target.pcd", *gen.GetTarget());
 
     SE3 T_target_source = gen.GetPose().inverse();
     LOG(INFO) << "gt pose: " << T_target_source.translation().transpose() << ", "

--- a/src/ch7/test/test_feature_extraction.cc
+++ b/src/ch7/test/test_feature_extraction.cc
@@ -9,6 +9,7 @@
 #include "common/io_utils.h"
 
 #include "common/timer/timer.h"
+#include "common/point_cloud_utils.h"
 
 /// 这里需要vlp16的数据，用wxb的
 DEFINE_string(bag_path, "./dataset/sad/wxb/test1.bag", "path to wxb bag");
@@ -34,8 +35,8 @@ int main(int argc, char** argv) {
                                    "Feature Extraction");
                                LOG(INFO) << "original pts:" << cloud->size() << ", corners: " << pcd_corner->size()
                                          << ", surf: " << pcd_surf->size();
-                               pcl::io::savePCDFileBinary("./data/ch7/corner.pcd", *pcd_corner);
-                               pcl::io::savePCDFileBinary("./data/ch7/surf.pcd", *pcd_surf);
+                               sad::SaveCloudToFile("./data/ch7/corner.pcd", *pcd_corner);
+                               sad::SaveCloudToFile("./data/ch7/surf.pcd", *pcd_surf);
                                return true;
                            })
         .Go();

--- a/src/ch7/test/test_icp.cc
+++ b/src/ch7/test/test_icp.cc
@@ -13,6 +13,7 @@
 #include "ch7/icp_3d.h"
 #include "ch7/ndt_3d.h"
 #include "common/sys_utils.h"
+#include "common/point_cloud_utils.h"
 
 DEFINE_string(source, "./data/ch7/EPFL/kneeling_lady_source.pcd", "第1个点云路径");
 DEFINE_string(target, "./data/ch7/EPFL/kneeling_lady_target.pcd", "第2个点云路径");
@@ -55,7 +56,7 @@ int main(int argc, char** argv) {
                           << ", " << pose.translation().transpose();
                 sad::CloudPtr source_trans(new sad::PointCloudType);
                 pcl::transformPointCloud(*source, *source_trans, pose.matrix().cast<float>());
-                pcl::io::savePCDFileBinaryCompressed("./data/ch7/icp_trans.pcd", *source_trans);
+                sad::SaveCloudToFile("./data/ch7/icp_trans.pcd", *source_trans);
             } else {
                 LOG(ERROR) << "align failed.";
             }
@@ -76,7 +77,7 @@ int main(int argc, char** argv) {
                           << ", " << pose.translation().transpose();
                 sad::CloudPtr source_trans(new sad::PointCloudType);
                 pcl::transformPointCloud(*source, *source_trans, pose.matrix().cast<float>());
-                pcl::io::savePCDFileBinaryCompressed("./data/ch7/icp_plane_trans.pcd", *source_trans);
+                sad::SaveCloudToFile("./data/ch7/icp_plane_trans.pcd", *source_trans);
             } else {
                 LOG(ERROR) << "align failed.";
             }
@@ -93,11 +94,11 @@ int main(int argc, char** argv) {
             SE3 pose;
             success = icp.AlignP2Line(pose);
             if (success) {
-                LOG(ERROR) << "icp p2line align success, pose: " << pose.so3().unit_quaternion().coeffs().transpose()
+                LOG(INFO) << "icp p2line align success, pose: " << pose.so3().unit_quaternion().coeffs().transpose()
                            << ", " << pose.translation().transpose();
                 sad::CloudPtr source_trans(new sad::PointCloudType);
                 pcl::transformPointCloud(*source, *source_trans, pose.matrix().cast<float>());
-                pcl::io::savePCDFileBinaryCompressed("./data/ch7/icp_line_trans.pcd", *source_trans);
+                sad::SaveCloudToFile("./data/ch7/icp_line_trans.pcd", *source_trans);
             } else {
                 LOG(ERROR) << "align failed.";
             }
@@ -118,11 +119,11 @@ int main(int argc, char** argv) {
             SE3 pose;
             success = ndt.AlignNdt(pose);
             if (success) {
-                LOG(ERROR) << "ndt align success, pose: " << pose.so3().unit_quaternion().coeffs().transpose() << ", "
+                LOG(INFO) << "ndt align success, pose: " << pose.so3().unit_quaternion().coeffs().transpose() << ", "
                            << pose.translation().transpose();
                 sad::CloudPtr source_trans(new sad::PointCloudType);
                 pcl::transformPointCloud(*source, *source_trans, pose.matrix().cast<float>());
-                pcl::io::savePCDFileBinaryCompressed("./data/ch7/ndt_trans.pcd", *source_trans);
+                sad::SaveCloudToFile("./data/ch7/ndt_trans.pcd", *source_trans);
             } else {
                 LOG(ERROR) << "align failed.";
             }
@@ -140,7 +141,7 @@ int main(int argc, char** argv) {
             SE3f T = SE3f(icp_pcl.getFinalTransformation());
             LOG(INFO) << "pose from icp pcl: " << T.so3().unit_quaternion().coeffs().transpose() << ", "
                       << T.translation().transpose();
-            pcl::io::savePCDFileBinaryCompressed("./data/ch7/pcl_icp_trans.pcd", *output_pcl);
+            sad::SaveCloudToFile("./data/ch7/pcl_icp_trans.pcd", *output_pcl);
 
             // 计算GT pose差异
             double pose_error = (gt_pose.inverse() * T.inverse().cast<double>()).log().norm();
@@ -160,7 +161,7 @@ int main(int argc, char** argv) {
             SE3f T = SE3f(ndt_pcl.getFinalTransformation());
             LOG(INFO) << "pose from ndt pcl: " << T.so3().unit_quaternion().coeffs().transpose() << ", "
                       << T.translation().transpose() << ', trans: ' << ndt_pcl.getTransformationProbability();
-            pcl::io::savePCDFileBinaryCompressed("./data/ch7/pcl_ndt_trans.pcd", *output_pcl);
+            sad::SaveCloudToFile("./data/ch7/pcl_ndt_trans.pcd", *output_pcl);
             LOG(INFO) << "score: " << ndt_pcl.getTransformationProbability();
 
             // 计算GT pose差异

--- a/src/ch8/CMakeLists.txt
+++ b/src/ch8/CMakeLists.txt
@@ -6,6 +6,7 @@ add_library(${PROJECT_NAME}.ch8
 target_link_libraries(${PROJECT_NAME}.ch8
         ${PROJECT_NAME}.ch7
         ${PROJECT_NAME}.ch3
+        ${PROJECT_NAME}.common
         ${third_party_libs}
         )
 

--- a/src/ch8/lio-iekf/lio_iekf.cc
+++ b/src/ch8/lio-iekf/lio_iekf.cc
@@ -14,6 +14,8 @@
 
 #include "common/lidar_utils.h"
 #include "common/timer/timer.h"
+#include "common/point_cloud_utils.h"
+
 #include "lio_iekf.h"
 
 namespace sad {
@@ -158,7 +160,7 @@ void LioIEKF::Undistort() {
     SE3 T_end = SE3(imu_state.R_, imu_state.p_);
 
     if (options_.save_motion_undistortion_pcd_) {
-        pcl::io::savePCDFileBinary("./data/ch7/before_undist.pcd", *cloud);
+        sad::SaveCloudToFile("./data/ch7/before_undist.pcd", *cloud);
     }
 
     /// 将所有点转到最后时刻状态上
@@ -181,7 +183,7 @@ void LioIEKF::Undistort() {
     scan_undistort_ = cloud;
 
     if (options_.save_motion_undistortion_pcd_) {
-        pcl::io::savePCDFileBinary("./data/ch7/after_undist.pcd", *cloud);
+        sad::SaveCloudToFile("./data/ch7/after_undist.pcd", *cloud);
     }
 }
 

--- a/src/ch9/CMakeLists.txt
+++ b/src/ch9/CMakeLists.txt
@@ -41,11 +41,13 @@ target_link_libraries(run_mapping
 add_executable(dump_map dump_map.cc)
 target_link_libraries(dump_map
         ${PROJECT_NAME}.ch9
+        ${PROJECT_NAME}.common
         ${third_party_libs}
         )
 
 add_executable(split_map split_map.cc)
 target_link_libraries(split_map
         ${PROJECT_NAME}.ch9
+        ${PROJECT_NAME}.common
         ${third_party_libs}
         )

--- a/src/ch9/dump_map.cc
+++ b/src/ch9/dump_map.cc
@@ -14,6 +14,7 @@ DEFINE_string(dump_to, "./data/ch9/", "导出的目标路径");
 #include <pcl/io/pcd_io.h>
 
 #include "keyframe.h"
+#include "common/point_cloud_utils.h"
 
 /**
  * 将keyframes.txt中的地图和点云合并为一个pcd
@@ -78,7 +79,7 @@ int main(int argc, char** argv) {
     }
 
     if (!global_cloud->empty()) {
-        pcl::io::savePCDFileBinaryCompressed(FLAGS_dump_to + "/map.pcd", *global_cloud);
+        sad::SaveCloudToFile(FLAGS_dump_to + "/map.pcd", *global_cloud);
     }
 
     LOG(INFO) << "done.";

--- a/src/ch9/keyframe.cc
+++ b/src/ch9/keyframe.cc
@@ -6,12 +6,13 @@
 #include <glog/logging.h>
 #include <pcl/io/pcd_io.h>
 #include <iomanip>
+#include "common/point_cloud_utils.h"
 
 namespace sad {
 
 void Keyframe::SaveAndUnloadScan(const std::string &path) {
     if (cloud_) {
-        pcl::io::savePCDFileBinaryCompressed(path + "/" + std::to_string(id_) + ".pcd", *cloud_);
+        sad::SaveCloudToFile(path + "/" + std::to_string(id_) + ".pcd", *cloud_);
         cloud_ = nullptr;
     }
 }

--- a/src/ch9/loopclosure.cc
+++ b/src/ch9/loopclosure.cc
@@ -120,7 +120,7 @@ void LoopClosure::ComputeForCandidate(sad::LoopCandidate& c) {
             auto kf = iter->second;
             CloudPtr cloud(new PointCloudType);
             pcl::io::loadPCDFile("./data/ch9/" + std::to_string(id) + ".pcd", *cloud);
-            RemoveGround(cloud, 0.1);
+            sad::RemoveGround(cloud, 0.1);
 
             if (cloud->empty()) {
                 continue;

--- a/src/ch9/split_map.cc
+++ b/src/ch9/split_map.cc
@@ -12,6 +12,7 @@
 #include "common/eigen_types.h"
 #include "common/point_cloud_utils.h"
 #include "keyframe.h"
+#include "common/point_cloud_utils.h"
 
 DEFINE_string(map_path, "./data/ch9/", "导出数据的目录");
 DEFINE_double(voxel_size, 0.1, "导出地图分辨率");
@@ -77,9 +78,9 @@ int main(int argc, char** argv) {
     for (auto& dp : map_data) {
         fout << dp.first[0] << " " << dp.first[1] << std::endl;
         dp.second->width = dp.second->size();
-        VoxelGrid(dp.second, 0.1);
+        sad::VoxelGrid(dp.second, 0.1);
 
-        pcl::io::savePCDFileBinaryCompressed(
+        sad::SaveCloudToFile(
             "./data/ch9/map_data/" + std::to_string(dp.first[0]) + "_" + std::to_string(dp.first[1]) + ".pcd",
             *dp.second);
     }

--- a/src/common/CMakeLists.txt
+++ b/src/common/CMakeLists.txt
@@ -5,6 +5,7 @@ add_library(${PROJECT_NAME}.common
         timer/timer.cc
         global_flags.cc
         g2o_types.cc
+        point_cloud_utils.cc
         )
 
 target_link_libraries(${PROJECT_NAME}.common

--- a/src/common/point_cloud_utils.cc
+++ b/src/common/point_cloud_utils.cc
@@ -1,0 +1,53 @@
+//
+// Created by BowenBZ on 2023/5/10.
+//
+
+#include "common/point_cloud_utils.h"
+#include "common/point_types.h"
+
+#include <pcl/filters/voxel_grid.h>
+#include <pcl/io/pcd_io.h>
+
+/// 点云的一些工具函数
+
+namespace sad {
+
+/// 体素滤波
+void VoxelGrid(CloudPtr cloud, float voxel_size) {
+    pcl::VoxelGrid<sad::PointType> voxel;
+    voxel.setLeafSize(voxel_size, voxel_size, voxel_size);
+    voxel.setInputCloud(cloud);
+
+    CloudPtr output(new PointCloudType);
+    voxel.filter(*output);
+    cloud->swap(*output);
+}
+
+/// 移除地面
+void RemoveGround(CloudPtr cloud, float z_min) {
+    CloudPtr output(new PointCloudType);
+    for (const auto& pt : cloud->points) {
+        if (pt.z > z_min) {
+            output->points.emplace_back(pt);
+        }
+    }
+
+    output->height = 1;
+    output->is_dense = false;
+    output->width = output->points.size();
+    cloud->swap(*output);
+}
+
+/// 写点云文件
+template<typename CloudType> 
+void SaveCloudToFile(const std::string &filePath, CloudType &cloud) {
+    cloud.height = 1;
+    cloud.width = cloud.size();
+    pcl::io::savePCDFileASCII(filePath, cloud);
+}
+
+template void SaveCloudToFile<PointCloudType>(const std::string &filePath, PointCloudType &cloud);
+
+template void SaveCloudToFile<FullPointCloudType>(const std::string &filePath, FullPointCloudType &cloud);
+
+}  // namespace sad

--- a/src/common/point_cloud_utils.h
+++ b/src/common/point_cloud_utils.h
@@ -7,37 +7,19 @@
 
 #include "common/point_types.h"
 
-#include <pcl/filters/voxel_grid.h>
-
 /// 点云的一些工具函数
 
 namespace sad {
 
 /// 体素滤波
-void VoxelGrid(CloudPtr cloud, float voxel_size = 0.05) {
-    pcl::VoxelGrid<sad::PointType> voxel;
-    voxel.setLeafSize(voxel_size, voxel_size, voxel_size);
-    voxel.setInputCloud(cloud);
-
-    CloudPtr output(new PointCloudType);
-    voxel.filter(*output);
-    cloud->swap(*output);
-}
+void VoxelGrid(CloudPtr cloud, float voxel_size = 0.05);
 
 /// 移除地面
-void RemoveGround(CloudPtr cloud, float z_min = 0.5) {
-    CloudPtr output(new PointCloudType);
-    for (const auto& pt : cloud->points) {
-        if (pt.z > z_min) {
-            output->points.emplace_back(pt);
-        }
-    }
+void RemoveGround(CloudPtr cloud, float z_min = 0.5);
 
-    output->height = 1;
-    output->is_dense = false;
-    output->width = output->points.size();
-    cloud->swap(*output);
-}
+/// 写点云文件
+template<typename CloudType> 
+void SaveCloudToFile(const std::string &filePath, CloudType &cloud);
 
 }  // namespace sad
 

--- a/src/tools/pcl_map_viewer.h
+++ b/src/tools/pcl_map_viewer.h
@@ -13,6 +13,7 @@
 #include <pcl/visualization/pcl_visualizer.h>
 
 #include "common/point_types.h"
+#include "common/point_cloud_utils.h"
 
 namespace sad {
 
@@ -67,7 +68,7 @@ class PCLMapViewer {
     /// 存储地图至PCD文件
     void SaveMap(std::string path) {
         if (local_map_->size() > 0) {
-            pcl::io::savePCDFileBinaryCompressed(path, *local_map_);
+            sad::SaveCloudToFile(path, *local_map_);
             LOG(INFO) << "save map to " << path;
         } else {
             LOG(INFO) << "map 是空的" << path;


### PR DESCRIPTION
Replace functions to save point cloud from `pcl::io` with `SaveCloudToFile` function, which firstly set the height and width property of the point cloud, and then save it. 

This is to avoid the "No points to read" issue when using `pcl_viewer` to load the saved pcd file. See #75 for details.

Since `pcl_map_viewer.h` includes the `point_cloud_utils.h` file, and the `pcl_map_viewer.h` is included by several source files in ch7, including `direct_ndt_lo.h`, `incremental_ndt_lo.h` and `loam_like_odom.h`, create a `point_cloud_utils.cc` file and move the definitions to it to avoid "multiple definition" compile errors. 