### PR TITLE
add `PCL_NO_PRECOMPILE` in point_types.h

### DIFF
--- a/src/common/point_types.h
+++ b/src/common/point_types.h
@@ -5,6 +5,7 @@
 #ifndef SLAM_IN_AUTO_DRIVING_POINT_TYPES_H
 #define SLAM_IN_AUTO_DRIVING_POINT_TYPES_H
 
+#define PCL_NO_PRECOMPILE
 #include <pcl/point_cloud.h>
 #include <pcl/point_types.h>
 #include <pcl/impl/pcl_base.hpp>


### PR DESCRIPTION
Hello, Dr. Gao. First, thank you for the great work you do in this repository. I'm learning the project

in `point_types.h`, I found the custom pointT type `FullPointType`. maybe need add `PCL_NO_PRECOMPILE` before include PCL headers.

here is my reference 
[PCL How to add a new PointT type](https://pcl.readthedocs.io/projects/tutorials/en/latest/adding_custom_ptype.html#how-to-add-a-new-pointt-type)
