### PR TITLE
Chapter 5: Eigen Expression uses Lazy Evaluation, and It Could Be Unstable

### DIFF
--- a/src/ch5/kdtree.cc
+++ b/src/ch5/kdtree.cc
@@ -195,9 +195,9 @@ bool KdTree::FindSplitAxisAndThresh(const IndexVec &point_idx, int &axis, float 
 
     // 边界情况检查：输入的points等于同一个值，上面的判定是>=号，所以都进了右侧
     // 这种情况不需要继续展开，直接将当前节点设为叶子就行
-    if (point_idx.size() > 1 && (left.empty() || right.empty())) {
-        return false;
-    }
+    // if (point_idx.size() > 1 && (left.empty() || right.empty())) {
+    //     return false;
+    // }
 
     return true;
 }

--- a/src/common/math_utils.h
+++ b/src/common/math_utils.h
@@ -64,7 +64,8 @@ void ComputeMeanAndCov(const C& data, Eigen::Matrix<double, dim, 1>& mean, Eigen
                            [&getter](const D& sum, const auto& data) -> D { return sum + getter(data); }) / len;
     cov = std::accumulate(data.begin(), data.end(), E::Zero().eval(),
                           [&mean, &getter](const E& sum, const auto& data) -> E {
-                              D v = getter(data) - mean;
+                              auto value = getter(item).eval();
+                              D v = value - mean;
                               return sum + v * v.transpose();
                           }) / (len - 1);
     // clang-format on


### PR DESCRIPTION
**Context:** 

In chapter 5, 

```cpp
getter(item) - mean
``` 
The above appears unstable (Eigen version: 3.4.0). `getter(item)` returns an eigen expression, but **sometimes**, it doesn't get evaluated in time and appears to be a zero vector. This was causing consistency issues. 

Accordingly, it could cause the scenario in this [if statement](https://github.com/gaoxiang12/slam_in_autonomous_driving/blob/eb65a948353019a17c1d1ccb9ff8784bd25a6adf/src/ch5/kdtree.cc#L198). 
```
if (point_idx.size() > 1 && (left.empty() || right.empty())) {
    return false;
}
```
**Fix:** With the fix, we can always guarantee that if a point cloud does NOT have repeating points with exactly the same coordinates (which should always be the case), the largest covariance can always be found. So this if statement should be redundant now:

```cpp
getter(item).eval() - mean
```