### PR TITLE
[bug-fix] in ndt_inc, fix memory continually rises due to VoxelData::AddPoint 

### DIFF
--- a/src/ch7/ndt_inc.cc
+++ b/src/ch7/ndt_inc.cc
@@ -70,6 +70,7 @@ void IncNdt3d::UpdateVoxel(VoxelData& v) {
     }
 
     if (v.ndt_estimated_ && v.num_pts_ > options_.max_pts_in_voxel_) {
+        v.pts_.clear();
         return;
     }
 


### PR DESCRIPTION
IncNdt3d::AddCloud may continuously add new points to existing voxels, causing VoxelData::pts_ to keep growing and, in turn, memory usage to keep increasing.